### PR TITLE
Make installShellFiles non-optional

### DIFF
--- a/pkgs/finalfrontier/default.nix
+++ b/pkgs/finalfrontier/default.nix
@@ -7,7 +7,7 @@
 
   # Native build inputs
 , gnumake
-, installShellFiles ? null # Available in 19.09 and later.
+, installShellFiles
 , pandoc
 
   # Build inputs
@@ -32,8 +32,7 @@ cargo_nix.rootCrate.build.override {
       pname = "finalfrontier";
       name = "${pname}-${attr.version}";
 
-      nativeBuildInputs = [ gnumake pandoc ] ++
-        lib.optional (!isNull installShellFiles) installShellFiles;
+      nativeBuildInputs = [ gnumake installShellFiles pandoc ];
 
       buildInputs = stdenv.lib.optionals stdenv.isDarwin [
         darwin.Security
@@ -58,7 +57,7 @@ cargo_nix.rootCrate.build.override {
         # Install man pages.
         mkdir -p "$out/share/man/man1"
         cp man/*.1 "$out/share/man/man1/"
-      '' + lib.optionalString (!isNull installShellFiles) ''
+
         # Install shell completions
         installShellCompletion finalfrontier.{bash,fish,zsh}
       '';

--- a/pkgs/finalfusion-utils/default.nix
+++ b/pkgs/finalfusion-utils/default.nix
@@ -5,7 +5,7 @@
 , fetchFromGitHub
 
 # Native build inputs
-, installShellFiles ? null # Available in 19.09 and later.
+, installShellFiles
 , perl
 , pkgconfig
 
@@ -43,7 +43,7 @@ let
       pname = "finalfusion-utils";
       name = "${pname}-${attr.version}";
 
-      nativeBuildInputs = lib.optional (!isNull installShellFiles) installShellFiles;
+      nativeBuildInputs = [ installShellFiles ];
 
       buildInputs = lib.optionals withOpenblas [ gfortran.cc.lib openblasCompat ]
         ++ stdenv.lib.optional stdenv.isDarwin darwin.Security;
@@ -57,7 +57,7 @@ let
 
       postInstall = ''
         rm $out/bin/*.d
-      '' + lib.optionalString (!isNull installShellFiles) ''
+
         # Install shell completions
         installShellCompletion finalfusion-utils.{bash,fish,zsh}
       '';


### PR DESCRIPTION
The installShellFiles derivation was included in 19.09. 19.03 is out
of support.