### PR TITLE
finalfrontier, finalfusion-utils: warn about future removal

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,11 +8,15 @@ in {
   modules = import ./modules;
   overlays = import ./overlays;
 
-  finalfrontier = pkgs.callPackage ./pkgs/finalfrontier {};
+  finalfrontier = builtins.trace
+    "finalfrontier is in nixpkgs since 2020-07-26. This attribute will become an alias nixpkgs 20.09 is released."
+    (pkgs.callPackage ./pkgs/finalfrontier {});
 
-  finalfusion-utils = pkgs.callPackage ./pkgs/finalfusion-utils {
-    withOpenblas = true;
-  };
+  finalfusion-utils = builtins.trace
+    "finalfusion-utils is in nixpkgs since 2020-08-05. This attribute will be an alias when nixpkgs 20.09 is released."
+    (pkgs.callPackage ./pkgs/finalfusion-utils {
+      withOpenblas = true;
+    });
 
   python3Packages = pkgs.recurseIntoAttrs(
     pkgs.python3Packages.callPackage ./pkgs/python-modules {}


### PR DESCRIPTION
@sebpuetz I am not 100% sure how to handle this. Do we want to remove these packages once nixpkgs/NixOS 20.09 lands? Or do we just want to make them aliases once the next release is out (perhaps with a warning).